### PR TITLE
Add function to clear IRQ

### DIFF
--- a/src/cpu650x.c
+++ b/src/cpu650x.c
@@ -1320,6 +1320,17 @@ void cpu_trigger_irq(void)
 }
 
 /**
+ * Clear maskable interrupt
+ */
+void cpu_clear_irq(void)
+{
+	s_lock();
+	if (CPU.state == CPU_RUNNING)
+		CPU.irq_trigger = 0;
+	s_unlock();
+}
+
+/**
  * Trigger non-maskable interrupt
  */
 void cpu_trigger_nmi(void)

--- a/src/cpu650x.h
+++ b/src/cpu650x.h
@@ -123,6 +123,7 @@ enum _CPU_STATE cpu_get_state();
 void cpu_clock(void);
 void cpu_reset(void);
 void cpu_trigger_irq(void);
+void cpu_clear_irq(void);
 void cpu_trigger_nmi(void);
 int cpu_register_kill_cb(void (*kill_cb)(cpu650x_state_t));
 int cpu_unregister_kill_cb(void);


### PR DESCRIPTION
Add the following function:

void cpu_clear_irq(void);

That allows to clear the IRQ flag.